### PR TITLE
Fix 2 typos in Palladino section

### DIFF
--- a/sections/section7_comparative_analysis.md
+++ b/sections/section7_comparative_analysis.md
@@ -12,12 +12,7 @@ Norwegian Singles employs a consistent year-round approach with sub-threshold as
 Norwegian Singles distributes quality evenly through the week (E-Q-E-Q-E-Q-LR) focusing primarily on sub-threshold work, while Pfitzinger incorporates medium-long midweek runs and uses more varied intensities (including VO2max and specific race-pace work). Pfitzinger's plans are explicitly designed with marathon-specific elements and feature more complex mesocycle periodization rather than Norwegian Singles' consistent weekly pattern.
 
 ## vs. Palladino Power Project
-Norwegian Singles are strictly sub-threshold intensities with very short recoveries, while Steve
-Palladino incorporates supra-threshold and V̇O₂ max workouts with longer recoveries averaging two to
-three minutes. Palladino plans have integrated CP (Critical Power) testing every four weeks, while
-the athlete running Norwegian Singles would need to integrate regular CP testing on their own.
-Critical power is measured in watts and describes the same LT2 boundary between the heavy and severe
-domains. If an athlete's CP is recent and valid, a power meter can be a excellent proxy as a lactate meter for dialing in the correct sub-threshold intensities.
+Norwegian Singles are strictly sub-threshold intensities with very short recoveries, while Steve Palladino incorporates supra-threshold and V̇O₂ max workouts with longer recoveries averaging two to three minutes. Palladino plans have integrated CP (Critical Power) testing every four weeks, while the athlete running Norwegian Singles would need to integrate regular CP testing on their own. Critical power is measured in watts and describes the same LT2 boundary between the heavy and severe domains. If an athlete's CP is recent and valid, a power meter can be a excellent proxy as a lactate meter for dialing in the correct sub-threshold intensities.
 
 ## vs. 80/20 Running (Polarized Training)
 Norwegian Singles dedicates ~20-25% of training *time* to sub-threshold work (just below LT2), while polarized models like 80/20 typically distribute the 20% "hard" training across a wider range of moderate-to-high intensities, often emphasizing work well above LT2 (Zone 5). The key difference is that Norwegian Singles concentrates quality in a narrow, controlled intensity band (high Zone 3/low Zone 4) to maximize sustainable load, whereas polarized training emphasizes a distinct separation between very easy (Zone 1-2) and very hard (Zone 4-5) work, often minimizing time spent near LT2. The "singles" approach seeks to avoid the potential pitfalls (injury, burnout, plateau) sometimes associated with the high-intensity component of traditional amateur plans.

--- a/sections/section7_comparative_analysis.md
+++ b/sections/section7_comparative_analysis.md
@@ -12,7 +12,12 @@ Norwegian Singles employs a consistent year-round approach with sub-threshold as
 Norwegian Singles distributes quality evenly through the week (E-Q-E-Q-E-Q-LR) focusing primarily on sub-threshold work, while Pfitzinger incorporates medium-long midweek runs and uses more varied intensities (including VO2max and specific race-pace work). Pfitzinger's plans are explicitly designed with marathon-specific elements and feature more complex mesocycle periodization rather than Norwegian Singles' consistent weekly pattern.
 
 ## vs. Palladino Power Project
-Norwegian Singles are strictly sub-threshold intensities with very short recoveries, while Steve Palladino incorporates supra-threshold and V̇O₂ max workouts with longer recoveries averaging two to three minutes. Palladino plans have integrated CP (Critical Power) testing every four weeks, while the athlete running Nowegian Singles would need to integrate regular CP testing on their own. Critical power is measured in watts and describes the same LT2 boundary between the heavy and severe domains. If an athelte's CP is recent and valid, a power meter can be a excellent proxy as a lactate meter for dialing in the correct sub-threshold intensities.
+Norwegian Singles are strictly sub-threshold intensities with very short recoveries, while Steve
+Palladino incorporates supra-threshold and V̇O₂ max workouts with longer recoveries averaging two to
+three minutes. Palladino plans have integrated CP (Critical Power) testing every four weeks, while
+the athlete running Norwegian Singles would need to integrate regular CP testing on their own.
+Critical power is measured in watts and describes the same LT2 boundary between the heavy and severe
+domains. If an athlete's CP is recent and valid, a power meter can be a excellent proxy as a lactate meter for dialing in the correct sub-threshold intensities.
 
 ## vs. 80/20 Running (Polarized Training)
 Norwegian Singles dedicates ~20-25% of training *time* to sub-threshold work (just below LT2), while polarized models like 80/20 typically distribute the 20% "hard" training across a wider range of moderate-to-high intensities, often emphasizing work well above LT2 (Zone 5). The key difference is that Norwegian Singles concentrates quality in a narrow, controlled intensity band (high Zone 3/low Zone 4) to maximize sustainable load, whereas polarized training emphasizes a distinct separation between very easy (Zone 1-2) and very hard (Zone 4-5) work, often minimizing time spent near LT2. The "singles" approach seeks to avoid the potential pitfalls (injury, burnout, plateau) sometimes associated with the high-intensity component of traditional amateur plans.


### PR DESCRIPTION
Caught two typos that I should have caught before the initial pull request: `s/Nowegian/Norwegian/` and `s/athelte’s/athlete's/`.